### PR TITLE
add logging and chat history recall

### DIFF
--- a/chat-common/src/org/chat/common/Messages.java
+++ b/chat-common/src/org/chat/common/Messages.java
@@ -16,6 +16,7 @@ public class Messages {
     public static final String PASSCHANGE_SUCCEED = "/passchange_succeed";
     public static final String NAMECHANGE_REQUEST = "/namechange_request";
     public static final String NAMECHANGE_SUCCEED = "/namechange_succeed";
+    public static final String HISTORY_LOG = "/history_log";
 
     public static final String MSG_SIGNUP_SUCCEED = "User %s successfully created";
     public static final String MSG_PASSCHANGE_SUCCEED = "Password for user %s has been successfully changed";
@@ -103,5 +104,9 @@ public class Messages {
 
     public static String getPasschangeFailed() {
         return FAILED + DELIMITER + MSG_PASSCHANGE_FAILED;
+    }
+
+    public static String getHistoryLog(String msg) {
+        return HISTORY_LOG + DELIMITER + msg;
     }
 }

--- a/history_Donald.txt
+++ b/history_Donald.txt
@@ -1,0 +1,103 @@
+15:24:49: Server: Duck connected.
+15:25:18: Duck: jhkhkjhfd
+15:25:20: Duck: fgdgdfgd
+15:25:21: Duck: dfgdfgdg
+15:25:22: Duck: fdgdfgdg
+15:25:23: Duck: dgfgdfgd
+15:25:51: Duck: fkdjhgkdfh
+15:36:45: Server: Duck connected.
+15:37:10: Duck: this is a second connection
+15:37:18: Duck: lkdjlfjks
+15:37:19: Duck: dsfdsfsd
+15:37:20: Duck: dsfsdfsd
+15:37:21: Duck: adsfasdf
+15:37:42: Server: Duck connected.
+15:38:03: Duck: this is third connection
+15:38:05: Duck: fdsdfgdfgdfg
+15:38:07: Duck: fgdfgdfgdfg
+15:38:15: Server: Duck connected.
+15:38:23: Duck: forth try!!!!!!!
+15:38:25: Duck: dfdfdf
+15:38:26: Duck: dfdfdf
+15:38:27: Duck: dfdfdf
+15:38:28: Duck: dfdfdf
+15:43:45: Server: Duck connected.
+15:43:55: Duck: fifth connection
+15:44:04: Duck: after Mickey attempt
+15:44:06: Duck: dsafdsf
+15:44:07: Duck: adsfadsf
+15:44:08: Duck: adsfa
+16:43:40: Server: Duck connected.
+16:44:13: Server: Bobby connected.
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:03: Server: Bobby disconnected
+16:45:16: Server: Mouse connected.
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:46:47: Server: Mouse disconnected
+16:47:45: Server: Duck connected.
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:42:35: Server: Duck connected.
+17:44:33: Server: Duck connected.
+17:44:50: Server: Duck connected.
+17:45:46: Server: Duck connected.
+17:46:24: Server: Duck connected.
+17:46:41: Server: Duck connected.
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:47:40: Server: Duck connected.
+17:51:45: Server: Duck connected.
+17:53:16: Server: Duck connected.
+17:56:01: Server: Duck connected.
+17:56:08: Duck: dfjhklkjdhslkdfh
+17:56:20: Server: Duck connected.
+17:57:12: Server: Duck connected.
+18:02:27: Server: Duck connected.
+18:02:38: Server: Duck connected.
+18:03:02: Server: Duck connected.
+18:03:34: Server: Duck connected.
+18:03:50: Server: Duck connected.
+18:06:25: Server: Duck connected.
+18:06:47: Server: Duck connected.
+18:10:35: Server: Duck connected.
+18:10:40: Server: Duck connected.
+18:10:44: Server: Duck connected.
+18:13:19: Server: Duck connected.
+18:13:25: Duck: fdfgdgdfgdfg
+18:13:29: Server: Duck connected.
+18:13:35: Server: Duck connected.
+18:18:52: Server: Duck connected.
+18:18:58: Server: Duck connected.
+18:19:13: Duck: --------------------------------------
+18:19:19: Server: Duck connected.
+18:22:23: Server: Duck connected.
+18:22:28: Server: Duck connected.
+18:22:47: Server: Mouse connected.
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+18:23:08: Server: Duck connected.
+18:23:28: Server: Mouse disconnected
+18:23:45: Server: Duck connected.
+21:56:07: Server: Duck connected.
+21:56:27: Server: Duck connected.
+21:57:23: Server: Duck connected.
+22:07:04: Server: Duck connected.
+22:07:58: Server: Duck connected.
+22:08:39: Server: Duck connected.
+22:09:20: Duck: 104
+22:09:23: Duck: 105
+22:09:25: Duck: 106
+22:10:24: Server: Duck connected.
+22:10:31: Duck: 107
+22:10:57: Server: Duck connected.
+00:32:17: Server: Duck connected.

--- a/history_Mickey.txt
+++ b/history_Mickey.txt
@@ -1,0 +1,37 @@
+15:43:17: Server: Mouse connected.
+15:43:29: Mouse: first attempt
+15:43:32: Mouse: kjhksdkla
+15:43:34: Mouse: jkhdkshkhlkjh
+15:43:36: Mouse: lkjhlkjlkhfsa
+15:44:15: Server: Mouse connected.
+15:44:36: Mouse: Second connection. Switched after Donald
+15:44:37: Mouse: gsgfsdfgs
+15:44:38: Mouse: sfgsfdgsd
+15:44:39: Mouse: sfgsfgsdf
+16:45:16: Server: Mouse connected.
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:47:44: Server: Mouse connected.
+16:47:45: Server: Duck connected.
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+16:48:21: Server: Duck disconnected
+17:45:01: Server: Mouse connected.
+17:56:53: Server: Mouse connected.
+17:57:12: Server: Duck connected.
+17:57:20: Server: Duck disconnected
+18:22:47: Server: Mouse connected.
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+18:23:06: Server: Duck disconnected
+18:23:08: Server: Duck connected.
+18:23:44: Server: Mouse connected.
+18:23:45: Server: Duck connected.
+18:24:08: Server: Duck disconnected
+22:08:13: Server: Mouse connected.
+22:08:21: Mouse: 101
+22:08:25: Mouse: 102
+22:08:26: Mouse: 103

--- a/history_Robert.txt
+++ b/history_Robert.txt
@@ -1,0 +1,6 @@
+16:44:13: Server: Bobby connected.
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd

--- a/pom.xml
+++ b/pom.xml
@@ -13,4 +13,17 @@
         <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.36.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.15.1</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/server_history_log.txt
+++ b/server_history_log.txt
@@ -1,0 +1,527 @@
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+16:44:21: Duck: Hi all!
+16:44:29: Bobby: Hi Duck!
+16:44:38: Bobby: hdjgjhgjdgfjhd
+16:44:42: Duck: dfhkjfhdkfhkdfkjd
+16:44:59: Bobby: hkjhsgdgdsfjd
+16:45:27: Mouse: Hey, Mickey's here!
+16:45:38: Duck: Hey Mickey!
+16:46:17: Mouse: dfgdfgd
+16:48:02: Mouse: After server was restarted
+16:48:18: Duck: and from here after restart
+17:46:45: Duck: dfgdfgdgf
+17:47:35: Duck: jhgkjkh
+17:47:36: Duck: fdsdfsdf
+17:47:37: Duck: dsfsdfsd
+17:56:08: Duck: dfjhklkjdhslkdfh
+18:13:25: Duck: fdfgdgdfgdfg
+18:19:13: Duck: --------------------------------------
+18:22:54: Mouse: jhgkjkjdgfska
+18:22:56: Mouse: dsfhsdfsdhfkljdhfkljas
+18:22:59: Mouse: dasdfsdfsfasfdasdsdfasddsfsdfs
+18:23:04: Mouse: last one
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+17
+18
+19
+20
+21
+22
+23
+24
+25
+26
+27
+28
+29
+30
+31
+32
+33
+34
+35
+36
+37
+38
+39
+40
+41
+42
+43
+44
+45
+46
+47
+48
+49
+50
+51
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68
+69
+70
+71
+72
+73
+74
+75
+76
+77
+78
+79
+80
+81
+82
+83
+84
+85
+86
+87
+88
+89
+90
+91
+92
+93
+94
+95
+96
+97
+98
+99
+100
+22:08:21: Mouse: 101
+22:08:25: Mouse: 102
+22:08:26: Mouse: 103
+22:09:20: Duck: 104
+22:09:23: Duck: 105
+22:09:25: Duck: 106
+22:10:31: Duck: 107


### PR DESCRIPTION
Практическое задание к третьему уроку.

1. Добавлено легирование истории чата на стороне пользователя. История сохраняется в разные файлы в зависимости от логина пользователя
2. Добавлена отправка пользователю ста последних строк чата при подключении. Выборка строк сделана при помощи библиотеки Apache Commons IO